### PR TITLE
Relax bundler requirement to allow 2.x

### DIFF
--- a/asset_paths_from_manifest.gemspec
+++ b/asset_paths_from_manifest.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "railties",      ">= 4.2"
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", ">= 1.13", "< 3.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "meowcop", "~> 2.6"


### PR DESCRIPTION
Nowadays many people install `bundler` 2.x.