### PR TITLE
Bump meowcop from 1.10 to 2.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
 
 # Modify the version if you don't use MRI 2.1.
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.4
   # If you use RuboCop with Ruby on Rails, specify TargetRailsVersion(default: 5.0).
   TargetRailsVersion: 5.0
 
@@ -18,3 +18,6 @@ Rails:
 # Style/FrozenStringLiteralComment:
 #   Enabled: true
 #   EnforcedStyle: always
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false

--- a/asset_paths_from_manifest.gemspec
+++ b/asset_paths_from_manifest.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "meowcop", "~> 1.10"
+  spec.add_development_dependency "meowcop", "~> 2.6"
 end


### PR DESCRIPTION
CIs for #1 #2 failed with meowcop/rubocop version mismatch.